### PR TITLE
Fixed issue with image interpolator crashing with coordinates out of image bounds

### DIFF
--- a/global.h
+++ b/global.h
@@ -50,6 +50,8 @@ typedef SnakeContainer::iterator SnakeIterator;
 typedef SnakeContainer::const_iterator SnakeConstIterator;
 
 typedef itk::LinearInterpolateImageFunction<ImageType> InterpolatorType;
+typedef itk::LinearInterpolateImageFunction<ImageType>::OutputType
+InterpolatorOutputType;
 typedef itk::VectorLinearInterpolateImageFunction<VectorImageType>
 VectorInterpolatorType;
 typedef itk::VersorTransform<double> TransformType;

--- a/multisnake.cc
+++ b/multisnake.cc
@@ -418,6 +418,23 @@ void Multisnake::ComputeImageGradient(bool reset) {
   vector_interpolator_->SetInputImage(external_force_);
 }
 
+InterpolatorOutputType Multisnake::InterpolateImageIntensity(PointType coords) const {
+  const ImageType::SizeType &size =
+      image_->GetLargestPossibleRegion().GetSize();
+
+  // Make sure the coords is within 0.5 pixels of image edge in each direction
+  if (coords[0] < -0.5)          coords[0] = -0.5;
+  if (coords[0] > size[0] - 0.5) coords[0] = size[0] - 0.5;
+
+  if (coords[1] < -0.5)          coords[1] = -0.5;
+  if (coords[1] > size[1] - 0.5) coords[1] = size[1] - 0.5;
+
+  if (coords[2] < - 0.5)         coords[2] = -0.5;
+  if (coords[2] > size[2] - 0.5) coords[2] = size[2] - 0.5;
+
+  return interpolator_->Evaluate(coords);
+}
+
 void Multisnake::InitializeSnakes() {
   this->ClearSnakeContainer(initial_snakes_);
   BoolVectorImageType::Pointer ridge_image =
@@ -1015,7 +1032,7 @@ void Multisnake::SaveSnakes(const SnakeContainer &snakes,
       if ((*it)->radial_save_foreground() == 0)
       {
           // if snake r_save_foreground is zero then do this
-          intensity = interpolator_->Evaluate((*it)->GetPoint(j));
+          intensity = InterpolateImageIntensity((*it)->GetPoint(j));
       }
       else
       {
@@ -1210,7 +1227,7 @@ void Multisnake::ComputePointDensityAndIntensity(const PointType &center,
       unsigned r = static_cast<unsigned>(center.EuclideanDistanceTo(p));
       if (r < max_r) {
         snaxel_counts[r]++;
-        snake_intensities[r] += interpolator_->Evaluate(p);
+        snake_intensities[r] += InterpolateImageIntensity(p);
       }
     }
   }

--- a/multisnake.h
+++ b/multisnake.h
@@ -105,6 +105,8 @@ class Multisnake : public QObject {
    */
   void ComputeImageGradient(bool reset = true);
 
+  InterpolatorOutputType InterpolateImageIntensity(PointType coords) const;
+  
   void InitializeSnakes();
 
   unsigned GetNumberOfInitialSnakes() const {

--- a/snake.h
+++ b/snake.h
@@ -197,6 +197,8 @@ class Snake {
   double ComputeForegroundMeanIntensity(unsigned index) const;
   double ComputeForegroundMeanIntensity2d(unsigned index) const;
 
+  InterpolatorOutputType InterpolateImageIntensity(PointType coords) const;
+
   /**
    * Return the average local SNR of the snake.
    */


### PR DESCRIPTION
Defined a new function in snake and in multisnake to do bounds checking before interpolating image brightness